### PR TITLE
Include problem_id in parquet outputs

### DIFF
--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -307,6 +307,7 @@ def inference(config: Config):
             proofs,
             ckpt_step,
             target_lengths,
+            [p["problem_id"] for p in problems],
         )
 
         # Save outputs to parquet file

--- a/src/zeroband/inference/parquet.py
+++ b/src/zeroband/inference/parquet.py
@@ -12,13 +12,20 @@ def get_parquet_table(
     proofs: list[bytes],
     step: int,
     target_lengths: list[int],
+    problem_ids: list[str],
 ) -> pa.Table:
     # Iterator over proofs
     proof_iter = iter(proofs)
 
     # Create flattened list of records for PyArrow table
     records = []
-    for request_output, request_rewards, prompt, target_length in zip(request_outputs, request_rewards, prompts, target_lengths):
+    for request_output, request_rewards, prompt, target_length, problem_id in zip(
+        request_outputs,
+        request_rewards,
+        prompts,
+        target_lengths,
+        problem_ids,
+    ):
         assert request_output.request_id == request_rewards.request_id
         for output, reward in zip(request_output.outputs, request_rewards.rewards):
             assert output.index == reward.completion_id
@@ -28,6 +35,7 @@ def get_parquet_table(
                     "output_tokens": output.token_ids,
                     "prompt": prompt,
                     "completion": output.text,
+                    "problem_id": str(problem_id),
                     "advantages": reward.advantage,
                     "rewards": reward.reward,
                     "task_rewards": reward.task_reward,

--- a/src/zeroband/utils/parquet.py
+++ b/src/zeroband/utils/parquet.py
@@ -5,6 +5,7 @@ pa_schema = pa.schema(
         ("input_tokens", pa.list_(pa.int32())),
         ("output_tokens", pa.list_(pa.int32())),
         ("prompt", pa.string()),
+        ("problem_id", pa.string()),
         ("completion", pa.string()),
         ("advantages", pa.float32()),
         ("rewards", pa.float32()),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,7 @@ def create_dummy_parquet_table(batch_size: int, seq_len: int) -> Table:
         "step": pa.array([0] * batch_size, type=pa.int32()),
         "target_lengths": pa.array([seq_len] * batch_size, type=pa.int32()),
         "task_type": pa.array(["test_task"] * batch_size, type=pa.string()),
+        "problem_id": pa.array(["0"] * batch_size, type=pa.string()),
     }
 
     # Create table directly from dictionary


### PR DESCRIPTION
## Summary
- add `problem_id` field to the parquet schema
- include problem ids in batches written during inference
- update dummy parquet generation for tests

## Testing
- `ruff check --fix src/zeroband/infer.py src/zeroband/inference/parquet.py src/zeroband/utils/parquet.py tests/conftest.py`
- `ruff format src/zeroband/infer.py src/zeroband/inference/parquet.py src/zeroband/utils/parquet.py tests/conftest.py`
- `pytest tests/unit/inference/test_prompts.py::test_format_prompts -q` *(fails: ModuleNotFoundError: No module named 'zeroband')*
- `pip install -e . --quiet` *(fails: Package 'zeroband' requires a different Python: 3.12.10 not in '==3.11.*')*

------
https://chatgpt.com/codex/tasks/task_e_684270b42d008328bf2424bbb150577b